### PR TITLE
{chrome,chromedriver}: use --disable-dev-shm-usage flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
   - export VERSION1=`docker run --name chrome --rm --entrypoint=/usr/bin/google-chrome-unstable $REPO --version | grep -Po '(?<=Google Chrome )[^ ]+'`
   - docker tag $REPO $REPO:latest
   - docker tag $REPO $REPO:$VERSION1
-  - docker run --init -it --rm --name chrome --shm-size=1024m --cap-add=SYS_ADMIN --entrypoint=/usr/bin/google-chrome-unstable $REPO:latest   --headless --disable-gpu --dump-dom http://info.cern.ch/hypertext/WWW/TheProject.html
+  - docker run --init -it --rm --name chrome --cap-add=SYS_ADMIN --entrypoint=/usr/bin/google-chrome-unstable $REPO:latest   --headless --disable-dev-shm-usage --disable-gpu --dump-dom http://info.cern.ch/hypertext/WWW/TheProject.html
 
 after_success:
   - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$VERSION0" != "$VERSION1" ]; then

--- a/chrome/Dockerfile
+++ b/chrome/Dockerfile
@@ -32,6 +32,7 @@ ENTRYPOINT ["/usr/bin/dumb-init", "--", \
             "/usr/bin/google-chrome-unstable", \
             "--disable-gpu", \
             "--headless", \
+            "--disable-dev-shm-usage", \
             "--remote-debugging-address=0.0.0.0", \
             "--remote-debugging-port=9222", \
             "--user-data-dir=/data"]

--- a/chromedriver/chrome_launcher.sh
+++ b/chromedriver/chrome_launcher.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec google-chrome-unstable --headless --disable-gpu "$@"
+exec google-chrome-unstable --disable-dev-shm-usage --headless --disable-gpu "$@"


### PR DESCRIPTION
This helps with /dev/shm usage in docker environments where changing the /dev/shm size is unavailable, for instance [in ECS](https://github.com/aws/amazon-ecs-agent/issues/787).

See https://bugs.chromium.org/p/chromium/issues/detail?id=736452#c56.
